### PR TITLE
The fstab required by MultiROM changing of mountpoints on secondary boot

### DIFF
--- a/fstab.qcom
+++ b/fstab.qcom
@@ -1,0 +1,19 @@
+# Android fstab file.
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+/dev/block/bootdevice/by-name/system         /system      ext4    ro,noatime,barrier=0                                                wait
+/dev/block/bootdevice/by-name/userdata       /data        ext4    noatime,nosuid,nodev,barrier=0,noauto_da_alloc              wait,check,formattable,encryptable=footer,length=-16384
+/dev/block/bootdevice/by-name/userdata       /data        f2fs    noatime,nosuid,nodev,inline_xattr,nobarrier                 wait,check,formattable,encryptable=footer,length=-16384
+/dev/block/bootdevice/by-name/cache          /cache       ext4    noatime,nodiratime,nosuid,nodev,barrier=0,noauto_da_alloc   wait,check
+/dev/block/bootdevice/by-name/cache          /cache       f2fs    noatime,nodiratime,nosuid,nodev,inline_xattr,nobarrier      wait,check
+/dev/block/bootdevice/by-name/persist        /persist     ext4    noatime,nodiratime,nosuid,nodev,barrier=0,noauto_da_alloc   wait,notrim
+/dev/block/bootdevice/by-name/boot           /boot        emmc    defaults                                                    defaults
+/dev/block/bootdevice/by-name/recovery       /recovery    emmc    defaults                                                    defaults
+/dev/block/bootdevice/by-name/misc           /misc        emmc    defaults                                                    defaults
+/dev/block/bootdevice/by-name/config         /persistent  emmc    defaults                                                    defaults
+/dev/block/bootdevice/by-name/modem          /firmware    vfat    ro,noatime,shortname=lower,uid=1000,gid=1026,dmask=227,fmask=337,context=u:object_r:firmware_file:s0    wait
+
+/devices/soc.0/7864900.sdhci/mmc_host*       auto         auto    defaults                                                    voldmanaged=sdcard1:auto,encryptable=userdata
+/devices/platform/msm_hsusb*                 auto         auto    defaults                                                    voldmanaged=usbdisk:auto
+/dev/block/zram0                             none         swap    defaults zramsize=536870912,zramstreams=3


### PR DESCRIPTION
Multirom always expects a fstab on the root of the ramdisk, and provides the same file structure with modified mountpoints. This fstab will act a fake fstab mounter since Sailfish doesn't make use of this type of fstab.
